### PR TITLE
Rename section to pass specStatus

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1461,7 +1461,7 @@ _:b a foaf:Person .
       "http://www.w3.org/TR/sparql11-protocol/">SPARQL 1.1 Protocol for RDF</a>.</p>
     </section>
     <section id="security-original">
-      <h2>Security Considerations (Informative)</h2>
+      <h2>Security Considerations</h2>
       <p>Exposing RDF data for update creates many security issues which all deployments must be aware of, and consider the risks involved. This submission discusses some of the potential issues. New
       security problems are discovered regularly, and each implementation introduces its own concerns. Consequently implementers should be aware that this is only a partial list containing possible
       issues, and cannot be considered complete nor authoritative.</p>


### PR DESCRIPTION
Makes `?specStatus=FPWD&pubDate=2023-04-01` as per WG editors guide.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-update/pull/11.html" title="Last updated on Mar 26, 2023, 3:53 PM UTC (1089716)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-update/11/520a5c3...1089716.html" title="Last updated on Mar 26, 2023, 3:53 PM UTC (1089716)">Diff</a>