### PR TITLE
Fixes reference links in the media type section

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1717,7 +1717,7 @@ _:b a foaf:Person .
     </section>
     <section id="mediaType">
       <h2>Internet Media Type, File Extension and Macintosh File Type</h2>
-      <p>The Internet Media Type / MIME Type for the SPARQL Update Language is "<code>application/sparql-update</code>".</p>
+      <p>The Internet Media Type (formerly known as MIME Type) for the SPARQL Update Language is "<code>application/sparql-update</code>".</p>
       <p>It is recommended that SPARQL Update files have the extension ".ru" (lowercase) on all platforms.</p>
       <p>It is recommended that SPARQL Update files stored on Macintosh HFS file systems be given a file type of "TEXT".</p>
       <div class="mime">

--- a/spec/index.html
+++ b/spec/index.html
@@ -1717,7 +1717,7 @@ _:b a foaf:Person .
     </section>
     <section id="mediaType">
       <h2>Internet Media Type, File Extension and Macintosh File Type</h2>
-      <p>The Internet Media Type / MIME Type for the SPARQL Update Language is "<code>/application/sparql-update</code>".</p>
+      <p>The Internet Media Type / MIME Type for the SPARQL Update Language is "<code>application/sparql-update</code>".</p>
       <p>It is recommended that SPARQL Update files have the extension ".ru" (lowercase) on all platforms.</p>
       <p>It is recommended that SPARQL Update files stored on Macintosh HFS file systems be given a file type of "TEXT".</p>
       <div class="mime">
@@ -1731,11 +1731,10 @@ _:b a foaf:Person .
           <dt>Optional parameters:</dt>
           <dd>None</dd>
           <dt>Encoding considerations:</dt>
-          <dd>The syntax of the SPARQL Update Language is expressed over code points in Unicode [<a href="#UNICODE">UNICODE</a>]. The encoding is always UTF-8 [<a href="#rfc3629">RFC3629</a>].</dd>
+          <dd>The syntax of the SPARQL Update Language is expressed over code points in Unicode [[UNICODE]]. The encoding is always UTF-8 [[RFC3629]].</dd>
           <dd>Unicode code points may also be expressed using an \uXXXX (U+0 to U+FFFF) or \UXXXXXXXX syntax (for U+10000 onwards) where X is a hexadecimal digit [0-9A-F]</dd>
           <dt>Security considerations:</dt>
-          <dd>See SPARQL Update appendix A, <a href="#security-original">Security Considerations</a> as well as <a class="norm" href="http://www.ietf.org/rfc/rfc3629.txt">RFC 3629</a> [<a href=
-          "#rfc3629">RFC3629</a>] section 7, Security Considerations.</dd>
+          <dd>See SPARQL Update appendix A, <a href="#security-original">Security Considerations</a> as well as [[[RFC3629]]] [[RFC3629]] section 7, Security Considerations.</dd>
           <dt>Interoperability considerations:</dt>
           <dd>There are no known interoperability issues.</dd>
           <dt>Published specification:</dt>
@@ -1758,7 +1757,7 @@ _:b a foaf:Person .
           <dt>Restrictions on usage:</dt>
           <dd>None</dd>
           <dt>Author/Change controller:</dt>
-          <dd>The SPARQL 1.2 specification is a work product of the World Wide Web Consortium's SPARQL Working Group. The W3C has change control over these specifications.</dd>
+          <dd>The SPARQL 1.2 specification is a work product of the World Wide Web Consortium's RDF-star Working Group. The W3C has change control over these specifications.</dd>
         </dl>
       </div>
     </section>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-update/pull/30.html" title="Last updated on Jul 6, 2023, 3:19 PM UTC (30028fd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-update/30/e788001...30028fd.html" title="Last updated on Jul 6, 2023, 3:19 PM UTC (30028fd)">Diff</a>