### PR TITLE
Fix missing migrations of @prefix to PREFIX

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -612,7 +612,7 @@ INSERT DATA
 </pre>
           <p>Data before is the empty graph.</p>
           <p>Data after:</p>
-          <pre class="data">@prefix : &lt;http://www.example.org/&gt; .
+          <pre class="data">PREFIX : &lt;http://www.example.org/&gt;
 :alice :claims &lt;&lt; :bob :age 23 &gt;&gt; .
 </pre>
           <p>If a <a data-cite="RDF12-CONCEPTS#dfn-quoted-triple">quoted triple</a> is to be present as an <a data-cite="RDF12-CONCEPTS#dfn-asserted-triple">asserted triple</a>,
@@ -625,7 +625,7 @@ INSERT DATA
 }
 </pre>
           <p>Data after:</p>
-          <pre class="data">@prefix : &lt;http://www.example.org/&gt; .
+          <pre class="data">PREFIX : &lt;http://www.example.org/&gt;
 :alice :claims &lt;&lt; :bob :age 23 &gt;&gt; .
 :bob :age 23 .
 </pre>
@@ -703,12 +703,12 @@ DELETE DATA
 }
 </pre>
           <p>Data before:</p>
-          <pre class="data">@prefix : &lt;http://www.example.org/&gt; .
+          <pre class="data">PREFIX : &lt;http://www.example.org/&gt;
 :alice :claims &lt;&lt; :bob :age 23 &gt;&gt; .
 :bob :age 23 .
 </pre>
           <p>Data after:</p>
-          <pre class="data">@prefix : &lt;http://www.example.org/&gt; .
+          <pre class="data">PREFIX : &lt;http://www.example.org/&gt;
 :bob :age 23 .
 </pre>
           <p>In contrast, deleting an <a data-cite="RDF12-CONCEPTS#dfn-asserted-triple">asserted triple</a> with the request shown below


### PR DESCRIPTION
Apparently we forgot some examples in the previous PR.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-update/pull/40.html" title="Last updated on Aug 28, 2024, 8:15 AM UTC (b946dd8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-update/40/a9a3cd8...b946dd8.html" title="Last updated on Aug 28, 2024, 8:15 AM UTC (b946dd8)">Diff</a>