### PR TITLE
GH-43: Update reified triples to reifying triples (inc links)

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -599,10 +599,10 @@ PREFIX ns: &lt;http://example.org/ns#&gt;
 &lt;http://example/book1&gt; ns:price 42 .
 </pre>
 
-          <p><strong>Example 3: Adding a reified triple</strong></p>
-          <p><span class="doc-ref" id="example_insert_reified"></span>
-              When inserting triples containing <a data-cite="RDF12-CONCEPTS#dfn-reified-triple">reified triples</a>,
-              these reified triples are not automatically inserted as <a data-cite="RDF12-CONCEPTS#dfn-asserted-triple">asserted triples</a>.
+          <p><strong>Example 3: Adding a reifying triple</strong></p>
+          <p><span class="doc-ref" id="example_insert_reifying"></span>
+              When inserting triples containing <a data-cite="RDF12-CONCEPTS#dfn-reifying-triple">reifying triples</a>,
+              these reifying triples are not automatically inserted as <a data-cite="RDF12-CONCEPTS#dfn-asserted-triple">asserted triples</a>.
               In other words, when executing the <code><a href="#insertData">INSERT DATA</a></code> operation below,
               the default graph will <em>not</em> contain the triple <code>:bob :age 23</code>.
           </p>
@@ -615,7 +615,7 @@ INSERT DATA
           <pre class="data">PREFIX : &lt;http://www.example.org/&gt;
 :alice :claims &lt;&lt; :bob :age 23 &gt;&gt; .
 </pre>
-          <p>If a <a data-cite="RDF12-CONCEPTS#dfn-reified-triple">reified triple</a> is to be present as an <a data-cite="RDF12-CONCEPTS#dfn-asserted-triple">asserted triple</a>,
+          <p>If a <a data-cite="RDF12-CONCEPTS#dfn-reifying-triple">reifying triple</a> is to be present as an <a data-cite="RDF12-CONCEPTS#dfn-asserted-triple">asserted triple</a>,
               then it needs to be explicitly inserted, through an operation like the following <code><a href="#insertData">INSERT DATA</a></code>.</p>
           <pre class="query nohighlight">PREFIX : &lt;http://www.example.org/&gt;
 INSERT DATA
@@ -688,10 +688,10 @@ PREFIX dc: &lt;http://purl.org/dc/elements/1.1/&gt;
 &lt;http://example/book1&gt; dc:title "Fundamentals of Compiler Design" .
 </pre>
 
-          <p><strong>Example 6: Removing a reified triple</strong></p>
-          <p><span class="doc-ref" id="example_delete_reified"></span>
-              When deleting triples containing <a data-cite="RDF12-CONCEPTS#dfn-reified-triple">reified triples</a>,
-              these reified triples are not automatically deleted as <a data-cite="RDF12-CONCEPTS#dfn-asserted-triple">asserted triples</a>.
+          <p><strong>Example 6: Removing a reifying triple</strong></p>
+          <p><span class="doc-ref" id="example_delete_reifying"></span>
+              When deleting triples containing <a data-cite="RDF12-CONCEPTS#dfn-reifying-triple">reifying triples</a>,
+              these reifying triples are not automatically deleted as <a data-cite="RDF12-CONCEPTS#dfn-asserted-triple">asserted triples</a>.
               In other words, when executing the <code><a href="#deleteData">DELETE DATA</a></code> operation below,
               the default graph will still contain the triple <code>:bob :age 23</code>
               if it was previously present as an <a data-cite="RDF12-CONCEPTS#dfn-asserted-triple">asserted triple</a>.
@@ -712,7 +712,7 @@ DELETE DATA
 :bob :age 23 .
 </pre>
           <p>In contrast, deleting an <a data-cite="RDF12-CONCEPTS#dfn-asserted-triple">asserted triple</a> with the request shown below
-             would <em>not</em> delete any triple containing this triple as a <a data-cite="RDF12-CONCEPTS#dfn-reified-triple">reified triple</a>.</p>
+             would <em>not</em> delete any triple containing this triple as a <a data-cite="RDF12-CONCEPTS#dfn-reifying-triple">reifying triple</a>.</p>
           <pre class="query nohighlight">PREFIX : &lt;http://www.example.org/&gt;
 DELETE DATA
 {
@@ -820,10 +820,10 @@ PREFIX foaf:  &lt;http://xmlns.com/foaf/0.1/&gt;
 &lt;http://example/president42&gt; foaf:familyName "Clinton" .
 </pre>
 
-          <p><strong>Example 8: Updating reified triples</strong></p>
+          <p><strong>Example 8: Updating reifying triples</strong></p>
           <p><span class="doc-ref" id="example_update_reified"></span>
               Just like with the <code><a href="#insertData">INSERT DATA</a></code> and <code><a href="#deleteData">DELETE DATA</a></code> operations,
-              inserting or deleting triples containing <a data-cite="RDF12-CONCEPTS#dfn-reified-triple">reified triples</a> does not automatically
+              inserting or deleting triples containing <a data-cite="RDF12-CONCEPTS#dfn-reifying-triple">reifying triples</a> does not automatically
               impact <a data-cite="RDF12-CONCEPTS#dfn-asserted-triple">asserted triples</a>.
               It is still possible to impact such triples by explicitly asserting them, as shown below.
           </p>
@@ -1848,7 +1848,7 @@ PREFIX foaf:  &lt;http://xmlns.com/foaf/0.1/&gt;
       <h2>Changes between SPARQL 1.1 Update and SPARQL 1.2 Update</h2>
       <ul>
         <li>Use Media Type language instead of MIME Type in <a href="#mediaType" class="sectionRef"></a></li>
-        <li>Add reified triples examples in <a href="#insertData" class="sectionRef"></a>, <a href="#deleteData" class="sectionRef"></a>, and <a href="#delete" class="sectionRef"></a></li>
+        <li>Add reifying triples examples in <a href="#insertData" class="sectionRef"></a>, <a href="#deleteData" class="sectionRef"></a>, and <a href="#delete" class="sectionRef"></a></li>
         
         <li>Use PREFIX instead of @prefix in all Turtle examples</li>
       </ul>


### PR DESCRIPTION
This closes #43.

RDF Concepts made a change to rename "reified triples" as "reifiying triples", including HTML anchors.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-update/pull/44.html" title="Last updated on Oct 24, 2024, 8:18 PM UTC (b3d43c2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-update/44/15329f9...b3d43c2.html" title="Last updated on Oct 24, 2024, 8:18 PM UTC (b3d43c2)">Diff</a>