### PR TITLE
LOAD RDF document clarification (description section and definition section)

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1904,6 +1904,7 @@ PREFIX foaf:  &lt;http://xmlns.com/foaf/0.1/&gt;
         <li>Add reifying triples examples in <a href="#insertData" class="sectionRef"></a>, <a href="#deleteData" class="sectionRef"></a>, and <a href="#delete" class="sectionRef"></a></li>
         
         <li>Use PREFIX instead of @prefix in all Turtle examples</li>
+        <li>Revise `LOAD` description and definition for handling RDF documents which contain a dataset</li>
       </ul>
     </section>
     

--- a/spec/index.html
+++ b/spec/index.html
@@ -1168,17 +1168,17 @@ PREFIX foaf:  &lt;http://xmlns.com/foaf/0.1/&gt;
         <section id="load">
           <h4>LOAD</h4>
           <p>
-            The `LOAD` operation reads an RDF document from a IRI and inserts triples
-            into the graphs of the dataset in the  <a href="#defn_graphStore">Graph Store</a>.
+            The `LOAD` operation reads an RDF document from an IRI and inserts triples
+            from the document into the <a href="#defn_graphStore">Graph Store</a>.
           </p>
 
           <pre class="defn nohighlight"><strong>LOAD</strong> ( <strong>SILENT</strong> )? <em><a
             data-cite="SPARQL12-QUERY#rIRIREF">IRIref_from</a></em> ( <strong>INTO GRAPH</strong> <em><a
             data-cite="SPARQL12-QUERY#rIRIREF">IRIref_to</a></em> )?</pre>
 
-          <p><em>IRIref_from</em> specifies the IRI of a document such that a store will be able to
-            identify, locate and read the document. The most common form of IRIs will be URLs with
-            the https and http IRI schemes.
+          <p><em>IRIref_from</em> specifies the IRI of a document, such that a store will be able to
+            identify, locate, and read the document. The most common IRIs will be URLs in
+            the `https` and `http` IRI schemes.
           </p>
 
           <p>If a destination graph (<i>IRIref_to</i>) is specified by `INTO GRAPH`, then the
@@ -1190,10 +1190,10 @@ PREFIX foaf:  &lt;http://xmlns.com/foaf/0.1/&gt;
             <a data-cite="RDF12-CONCEPTS#dfn-rdf-graph">RDF Graph</a>.
             This graph is
             <a data-cite="RDF12-SEMANTICS#dfn-merging">merged</a> into the destination
-            graph in the graph store..
+            graph in the graph store.
           </p>
           <p>
-            If no destination graph IRI is specified by `INTO`, then the RDF document is retrived
+            If no destination graph IRI is specified by `INTO`, then the RDF document is retrieved
             and parsed into an <a data-cite="RDF12-CONCEPTS#dfn-rdf-dataset">RDF Dataset</a>. 
             This dataset is <a data-cite="RDF12-SEMANTICS#dfn-rdf-dataset-merge">merged</a> into the
             <a href="#defn_graphStore">graph store</a> viewed as a mutable
@@ -1201,25 +1201,22 @@ PREFIX foaf:  &lt;http://xmlns.com/foaf/0.1/&gt;
           </p>
 
           <p>
-            In the case where no RDF data can be retrieved (as opposed to the empty graph being retrieved)
-            from the IRI denoted by <em>IRIref_from</em>, or in case the retrieval method returns an
-            error (such as, for instance an HTTP error code), the SPARQL 1.2 Update service SHOULD
-            return failure and the status of the Graph Store SHOULD remain in the same status as
-            prior to the request; in case the keyword `SILENT` is present, however, the
-            operation will still return success and the status of the Graph Store is not specified
-            by the present document: implementations may create the destination graph or not and
-            partially load data, in case of a transmission error where partial data has been
-            received (which itself may be legal RDF).
+            If no RDF data can be retrieved (as opposed to an empty graph being retrieved) from the
+            IRI denoted by <em>IRIref_from</em>, or in case the retrieval method returns an error
+            (such as, for instance an HTTP error code), the SPARQL 1.2 Update service SHOULD return
+            failure and the status of the Graph Store SHOULD remain in the same status as prior to
+            the request. However, if the the keyword `SILENT` is present, operation will return
+            success, rather than failure, and the status of the Graph Store is is not specified.
           </p>
 
           <div class="note" id="context-triples">
             <p>
-              Some RDF syntaxes, such as [[[JSON-LD11]]], is often used for data which
-              is a single graph, with no graph name. [[[RDF12-N-QUADS]]] may be used as a
+              Some RDF syntaxes, such as [[[JSON-LD11]]], are often used to serialize
+              a single graph with no graph name.
+              [[[RDF12-N-QUADS]]] may be used as a
               database dump format for a triple store with the data only in the default graph.
-              In both cases, this is not known until the entire RDF document content is parsed. 
               When the `LOAD` operation has an `INTO GRAPH` clause, it is an error if
-              named graphs are encountered.
+              named graphs are encountered when parsing the RDF document.
             </p>
           </div>
         </section>
@@ -1608,8 +1605,8 @@ PREFIX foaf:  &lt;http://xmlns.com/foaf/0.1/&gt;
           <div class="defn">
             <p><strong><span class="doc-ref" id="defn_loadOperation">Definition: Load Operation</span></strong></p>
             <p>
-              A <a href="#load">Load Operation</a> OpLoad is an Update Operation in which new
-              triples (from a remote graph or dataset) are added in the Graph Store, either in the
+              A <a href="#load">Load Operation</a> `OpLoad` is an Update Operation in which new
+              triples (from a remote graph or dataset) are added to the Graph Store, either in the
               default slot or in a named slot, if specified.
             </p>
 
@@ -1619,18 +1616,21 @@ PREFIX foaf:  &lt;http://xmlns.com/foaf/0.1/&gt;
 
             <p>where</p>
             <ul>
-              <li>The operation "dataset ( <em>documentIRI</em> )" is a function returning the RDF dataset serialized by the
-                RDF document</li>
-              <li>The operation "graph ( <em>documentIRI</em> )" is a function returning the RDF graph serialized by the
-                RDF document</li>
+              <li>The operation <code>dataset ( <em>documentIRI</em> )</code> is a function
+                returning the RDF dataset serialized by the RDF document</li>
+              <li>The operation <code>graph ( <em>documentIRI</em> )</code> is a function
+                returning the RDF graph serialized by the RDF document</li>
               <li>
-                The operation <a data-cite="RDF12-SEMANTICS#dfn-rdf-dataset-merge">dataset-merge</a>
-                combines the Graph Store GS with the given dataset constructed as shown
+                The operation `dataset-merge` combines the Graph Store GS with the given
+                dataset using the 
+                <a data-cite="RDF12-SEMANTICS#dfn-rdf-dataset-merge">dataset merge operation</a>
               </li>
             </ul>
-            <p>Blank nodes present in the retrieved graph or dataset are "standardized apart"; i.e.,
-              blank nodes from a loaded graph or dataset need to be disjoint with the blank nodes
-              already present in the Graph Store GS.
+            <p>
+              Blank nodes present in the retrieved graph or dataset are
+              "standardized apart"; i.e., blank nodes from a loaded graph or
+              dataset are disjoint from the blank nodes already present in the
+              Graph Store GS.
             </p>
           </div>
         </section>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1164,23 +1164,66 @@ PREFIX foaf:  &lt;http://xmlns.com/foaf/0.1/&gt;
 &lt;http://example/william&gt; foaf:mbox  &lt;mailto:bill@example&gt; .</pre>
           </section>
         </section>
+
         <section id="load">
           <h4>LOAD</h4>
-          <p>The <code>LOAD</code> operation reads an RDF document from a IRI and inserts its triples into the specified graph in the Graph Store.
-            The specified destination graph SHOULD be created if required; again, implementations providing an update service over a fixed set of
-            graphs MUST return with failure for a request that would create a disallowed graph. If the destination graph already exists, then no data in that graph will be
-            removed.</p>
-          <pre class="defn nohighlight"><strong>LOAD</strong> ( <strong>SILENT</strong> )? <em><a data-cite=
-          "SPARQL12-QUERY#rIRIREF">IRIref_from</a></em> ( <strong>INTO GRAPH</strong> <em><a data-cite="SPARQL12-QUERY#rIRIREF">IRIref_to</a></em> )?</pre>
-          <p><em>IRIref_from</em> specifies the IRI of a document such that a store will be able to identify, locate and read the document. The most common form will be URLs with the <em>http</em>
-          IRI schemes. Once the document has been read, the resulting triples will be inserted into the destination graph named by the IRI referred to by <em>IRIref_to</em>.</p>
-          <p>If no destination graph IRI (<em>IRIref_to</em>) is provided to load the triples into, then the data will be loaded into the default graph.</p>
-          <p>In case no RDF data can be retrieved (as opposed to the empty graph being retrieved) from the IRI denoted by <em>IRIref_from</em>, or in case the retrieval method returns an error (such
-          as, for instance an HTTP error code), the SPARQL 1.2 Update service SHOULD return failure and the status of the Graph Store
-          SHOULD remain in the same status as prior to the request; in case the keyword SILENT is present, however, the operation will
-          still return success and the status of the Graph Store is not specified by the present document: implementations may create the destination graph or not and partially load data, in case of
-          a transmission error where partial data has been received (which itself may be legal RDF).</p>
+          <p>
+            The `LOAD` operation reads an RDF document from a IRI and inserts triples
+            into the graphs of the dataset in the  <a href="#defn_graphStore">Graph Store</a>.
+          </p>
+
+          <pre class="defn nohighlight"><strong>LOAD</strong> ( <strong>SILENT</strong> )? <em><a
+            data-cite="SPARQL12-QUERY#rIRIREF">IRIref_from</a></em> ( <strong>INTO GRAPH</strong> <em><a
+            data-cite="SPARQL12-QUERY#rIRIREF">IRIref_to</a></em> )?</pre>
+
+          <p><em>IRIref_from</em> specifies the IRI of a document such that a store will be able to
+            identify, locate and read the document. The most common form of IRIs will be URLs with
+            the https and http IRI schemes.
+          </p>
+
+          <p>If a destination graph (<i>IRIref_to</i>) is specified by `INTO GRAPH`, then the
+            specified destination graph SHOULD be created if required; again, implementations
+            providing an update service over a fixed set of graphs MUST return with failure for a
+            request that would create a disallowed graph. If the destination graph already exists,
+            then no data in that graph will be removed. 
+            The RDF document is retrieved and parsed to produce an
+            <a data-cite="RDF12-CONCEPTS#dfn-rdf-graph">RDF Graph</a>.
+            This graph is
+            <a data-cite="RDF12-SEMANTICS#dfn-merging">merged</a> into the destination
+            graph in the graph store..
+          </p>
+          <p>
+            If no destination graph IRI is specified by `INTO`, then the RDF document is retrived
+            and parsed into an <a data-cite="RDF12-CONCEPTS#dfn-rdf-dataset">RDF Dataset</a>. 
+            This dataset is <a data-cite="RDF12-SEMANTICS#dfn-rdf-dataset-merge">merged</a> into the
+            <a href="#defn_graphStore">graph store</a> viewed as a mutable
+            <a data-cite="SPARQL12-QUERY#sparqlDataset">RDF Dataset</a>.
+          </p>
+
+          <p>
+            In the case where no RDF data can be retrieved (as opposed to the empty graph being retrieved)
+            from the IRI denoted by <em>IRIref_from</em>, or in case the retrieval method returns an
+            error (such as, for instance an HTTP error code), the SPARQL 1.2 Update service SHOULD
+            return failure and the status of the Graph Store SHOULD remain in the same status as
+            prior to the request; in case the keyword `SILENT` is present, however, the
+            operation will still return success and the status of the Graph Store is not specified
+            by the present document: implementations may create the destination graph or not and
+            partially load data, in case of a transmission error where partial data has been
+            received (which itself may be legal RDF).
+          </p>
+
+          <div class="note" id="context-triples">
+            <p>
+              Some RDF syntaxes, such as [[[JSON-LD11]]], is often used for data which
+              is a single graph, with no graph name. [[[RDF12-N-QUADS]]] may be used as a
+              database dump format for a triple store with the data only in the default graph.
+              In both cases, this is not known until the entire RDF document content is parsed. 
+              When the `LOAD` operation has an `INTO GRAPH` clause, it is an error if
+              named graphs are encountered.
+            </p>
+          </div>
         </section>
+
         <section id="clear">
           <h4>CLEAR</h4>
           <p>The <code>CLEAR</code> operation removes all the triples in the specified graph(s) in the Graph Store.</p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1607,12 +1607,31 @@ PREFIX foaf:  &lt;http://xmlns.com/foaf/0.1/&gt;
           <h4>Load Operation</h4>
           <div class="defn">
             <p><strong><span class="doc-ref" id="defn_loadOperation">Definition: Load Operation</span></strong></p>
-            <p>A <a href="#load">Load Operation</a> OpLoad is an Update Operation in which new triples (from a remote graph) are added in the Graph Store, either in the default slot or in a named
-            slot, if specified.</p>
-            <p>OpLoad ( GS, <em>documentIRI</em>) = Dataset-UNION ( GS, { graph ( <em>documentIRI</em> ) } )</p>
-            <p>OpLoad ( GS, <em>documentIRI</em>, <em>iri</em> ) = Dataset-UNION(GS, { {}, ( <em>iri</em>, graph ( <em>documentIRI</em> ) ) } )</p>
-            <p>where graph(<em>documentIRI</em>) is a function returning the RDF graph serialized by the RDF document retrieved from IRI <em>documentIRI</em>, where blank nodes present in the
-            retrieved graph are supposed to be "standardized apart"; i.e., blank nodes from a loaded graph need to be disjoint with the blank nodes already present in the Graph Store GS.</p>
+            <p>
+              A <a href="#load">Load Operation</a> OpLoad is an Update Operation in which new
+              triples (from a remote graph or dataset) are added in the Graph Store, either in the
+              default slot or in a named slot, if specified.
+            </p>
+
+            <p>OpLoad ( GS, <em>documentIRI</em>) = dataset-merge ( GS, dataset ( <em>documentIRI</em> ) } )</p>
+
+            <p>OpLoad ( GS, <em>documentIRI</em>, <em>iri</em> ) = dataset-merge(GS, { {}, ( <em>iri</em>, graph ( <em>documentIRI</em> ) ) } )</p>
+
+            <p>where</p>
+            <ul>
+              <li>The operation "dataset ( <em>documentIRI</em> )" is a function returning the RDF dataset serialized by the
+                RDF document</li>
+              <li>The operation "graph ( <em>documentIRI</em> )" is a function returning the RDF graph serialized by the
+                RDF document</li>
+              <li>
+                The operation <a data-cite="RDF12-SEMANTICS#dfn-rdf-dataset-merge">dataset-merge</a>
+                combines the Graph Store GS with the given dataset constructed as shown
+              </li>
+            </ul>
+            <p>Blank nodes present in the retrieved graph or dataset are "standardized apart"; i.e.,
+              blank nodes from a loaded graph or dataset need to be disjoint with the blank nodes
+              already present in the Graph Store GS.
+            </p>
           </div>
         </section>
         <section id="def_clearOperation">


### PR DESCRIPTION
This closes #41.

This PR changes the description section for `LOAD` to cover the case where the RDF Document is a quads format.

There is a note that encountering quads/named graph when expecting triples is an error.

See issue #41 for discussion about that.

This PR is draft at the moment; revisions of the formal LOAD definition section to come.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-update/pull/46.html" title="Last updated on Dec 10, 2024, 11:04 AM UTC (a136ddd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-update/46/870c717...a136ddd.html" title="Last updated on Dec 10, 2024, 11:04 AM UTC (a136ddd)">Diff</a>