### PR TITLE
Remove local .note CSS styling

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -116,9 +116,6 @@ pre.prototype	{ background-color:#f7f8ff;
                   margin: 1em 4em 1em 0em ; }
 .return, .type	{ color: #177 }
 
-/* == Notes ==  */
-.note		{ margin-left: 2.5em; margin-right: 4ex ; font-size: 85% ; font-style: italic ; }
-
 /* Definitions */
 .defn		{ margin-left:0 ; margin-right: 2ex; 
                   margin-top: 0.1ex ; margin-bottom: 0.1ex ;


### PR DESCRIPTION
See w3c/sparql-query#168


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-update/pull/47.html" title="Last updated on Nov 30, 2024, 5:14 PM UTC (73733c7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-update/47/e9e093b...73733c7.html" title="Last updated on Nov 30, 2024, 5:14 PM UTC (73733c7)">Diff</a>