### PR TITLE
Update links in SPARQL update conformance for syntax

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1821,8 +1821,16 @@ PREFIX foaf:  &lt;http://xmlns.com/foaf/0.1/&gt;
     </section>
     <section id="conformance">
       <h2>Conformance</h2>
-      <p>See <a href="#grammar">appendix B SPARQL 1.2 Update Grammar</a> regarding conformance of SPARQL Update strings.</p>
-      <p>This specification is intended for use in conjunction with: the [[[SPARQL12-GRAPH-STORE-PROTOCOL]]] and the [[[SPARQL12-PROTOCOL]]].</p>
+      <p>See 
+        <a data-cite="SPARQL12-QUERY#dfn-sparql-update-string">SPARQL update string</a>
+        and the <a data-cite="SPARQL12-QUERY#grammar">SPARQL grammar</a>
+        regarding the SPARQL update language.
+      </p>
+      <p>
+        This specification is intended for use in conjunction with: 
+        the [[[SPARQL12-GRAPH-STORE-PROTOCOL]]]
+        and the [[[SPARQL12-PROTOCOL]]].
+      </p>
     </section>
     <section id="security-original">
       <h2>Security Considerations</h2>


### PR DESCRIPTION
See w3c/sparql-query#190


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-update/pull/52.html" title="Last updated on Jan 29, 2025, 6:00 PM UTC (af757d4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-update/52/08d5590...af757d4.html" title="Last updated on Jan 29, 2025, 6:00 PM UTC (af757d4)">Diff</a>