### PR TITLE
Remove Macintosh file type code in media type section.

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1854,10 +1854,9 @@ PREFIX foaf:  &lt;http://xmlns.com/foaf/0.1/&gt;
       </ul>
     </section>
     <section id="mediaType">
-      <h2>Internet Media Type, File Extension and Macintosh File Type</h2>
+      <h2>Internet Media Type and File Extension</h2>
       <p>The Internet Media Type (formerly known as MIME Type) for the SPARQL Update Language is "<code>application/sparql-update</code>".</p>
       <p>It is recommended that SPARQL Update files have the extension ".ru" (lowercase) on all platforms.</p>
-      <p>It is recommended that SPARQL Update files stored on Macintosh HFS file systems be given a file type of "TEXT".</p>
       <div class="mime">
         <dl>
           <dt>Type name:</dt>
@@ -1886,8 +1885,6 @@ PREFIX foaf:  &lt;http://xmlns.com/foaf/0.1/&gt;
           <dd>".ru"</dd>
           <dt>Base IRI:</dt>
           <dd>The SPARQL 'BASE &lt;IRIref&gt;' term can change the current base IRI for relative IRIrefs in the query language that are used sequentially later in the document.</dd>
-          <dt>Macintosh file type code(s):</dt>
-          <dd>"TEXT"</dd>
           <dt>Person &amp; email address to contact for further information:</dt>
           <dd>public-rdf-dawg-comments@w3.org</dd>
           <dt>Intended usage:</dt>


### PR DESCRIPTION
w3c/rdf-star-wg#194


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-update/pull/59.html" title="Last updated on Jun 12, 2026, 3:19 PM UTC (079f1e2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-update/59/f1a3ece...079f1e2.html" title="Last updated on Jun 12, 2026, 3:19 PM UTC (079f1e2)">Diff</a>